### PR TITLE
SSR 38: fixed delivery fee calculation by delivery method

### DIFF
--- a/backend/app/repositories/order_repo.py
+++ b/backend/app/repositories/order_repo.py
@@ -34,9 +34,12 @@ def _alloc_order_item_id() -> int:
 def create_order_record(
     delivery_address: str,
     items: List[Dict[str, Any]],
+    delivery_method: str = "walk",
     status: str = "Pending",
 ) -> Dict[str, Any]:
     """Create and store a new order record.
+
+    Delivery method must be one of: walk, bike, car.
 
     Items must include:
     - quantity
@@ -62,6 +65,7 @@ def create_order_record(
         "order_id": order_id,
         "status": status,
         "delivery_address": delivery_address,
+        "delivery_method": delivery_method,
         "subtotal": "0.00",
         "tax": "0.00",
         "delivery_fee": "0.00",
@@ -87,6 +91,8 @@ def update_order_record(order_id: int, patch: Dict[str, Any]) -> Optional[Dict[s
         order["status"] = patch["status"]
     if "delivery_address" in patch:
         order["delivery_address"] = patch["delivery_address"]
+    if "delivery_method" in patch:
+        order["delivery_method"] = patch["delivery_method"]
     if "subtotal" in patch:
         order["subtotal"] = str(patch["subtotal"])
     if "tax" in patch:

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -26,6 +26,14 @@ class OrderStatus(str, Enum):
     CANCELLED = "Cancelled"
 
 
+class DeliveryMethod(str, Enum):
+    """Valid delivery methods for an order."""
+
+    WALK = "walk"
+    BIKE = "bike"
+    CAR = "car"
+
+
 class OrderItemBase(OrderSchemaModel):
     """Base schema for order item fields."""
 
@@ -50,6 +58,7 @@ class OrderBase(OrderSchemaModel):
     """Base schema for order fields."""
 
     delivery_address: str
+    delivery_method: DeliveryMethod
     status: OrderStatus = OrderStatus.PENDING
 
 
@@ -64,6 +73,7 @@ class OrderUpdate(OrderSchemaModel):
 
     status: Optional[OrderStatus] = None
     delivery_address: Optional[str] = None
+    delivery_method: Optional[DeliveryMethod] = None
     items: Optional[list[OrderItemCreate]] = None
 
 

--- a/backend/app/services/pricing_service.py
+++ b/backend/app/services/pricing_service.py
@@ -4,14 +4,21 @@ from decimal import Decimal, ROUND_HALF_UP
 
 TWOPLACES = Decimal("0.01")
 
+
 def _to_money(value: object) -> Decimal:
     """Convert a value to a 2-decimal Decimal using half-up rounding."""
     return Decimal(str(value)).quantize(TWOPLACES, rounding=ROUND_HALF_UP)
 
+
 class PricingService:
-    """Service for calculating order subtotal, tax, and total."""
+    """Service for calculating order subtotal, tax, delivery fee, and total."""
 
     DEFAULT_TAX_RATE = Decimal("0.10")
+    DELIVERY_FEE_BY_METHOD = {
+        "walk": Decimal("5.00"),
+        "bike": Decimal("8.00"),
+        "car": Decimal("10.00"),
+    }
 
     @staticmethod
     def calculate_tax(subtotal: Decimal, tax_rate: Decimal) -> Decimal:
@@ -19,8 +26,20 @@ class PricingService:
         return (subtotal * tax_rate).quantize(TWOPLACES, rounding=ROUND_HALF_UP)
 
     @staticmethod
+    def calculate_delivery_fee(delivery_method: str) -> Decimal:
+        """Calculate fixed delivery fee based on delivery method."""
+        method = getattr(delivery_method, "value", delivery_method)
+        method = str(method)
+
+        fee = PricingService.DELIVERY_FEE_BY_METHOD.get(method)
+        if fee is None:
+            raise ValueError("Delivery method must be one of: walk, bike, car")
+
+        return fee.quantize(TWOPLACES, rounding=ROUND_HALF_UP)
+
+    @staticmethod
     def calculate_totals(order) -> None:
-        """Mutate order fields with recalculated totals."""
+        """Mutate order fields with recalculated subtotal, tax, delivery fee, and total."""
         subtotal = Decimal("0.00")
 
         for item in order.items:
@@ -36,7 +55,8 @@ class PricingService:
             subtotal += line_total
 
         subtotal = subtotal.quantize(TWOPLACES, rounding=ROUND_HALF_UP)
-        delivery_fee = _to_money(getattr(order, "delivery_fee", 0))
+        delivery_method = getattr(order, "delivery_method", None)
+        delivery_fee = PricingService.calculate_delivery_fee(delivery_method)
         tax_rate = Decimal(str(getattr(order, "tax_rate", PricingService.DEFAULT_TAX_RATE)))
         tax = PricingService.calculate_tax(subtotal, tax_rate)
         total = (subtotal + delivery_fee + tax).quantize(TWOPLACES, rounding=ROUND_HALF_UP)

--- a/backend/tests/test_pricing_service.py
+++ b/backend/tests/test_pricing_service.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from decimal import Decimal
 
+import pytest
+
 from backend.app.services.pricing_service import PricingService
 
 
@@ -23,65 +25,96 @@ class Order:  # pylint: disable=too-many-instance-attributes
     status: str
     items: list[OrderItem]
     delivery_address: str
+    delivery_method: object = "walk"
     subtotal: Decimal = Decimal("0.00")
     tax: Decimal = Decimal("0.00")
-    delivery_fee: object = Decimal("0.00")
+    tax_rate: object = Decimal("0.10")
+    delivery_fee: Decimal = Decimal("0.00")
     total: Decimal = Decimal("0.00")
 
 
-def test_calculate_totals_basic():
-    """Test that calculate_totals correctly computes subtotal, tax, and total for a simple order."""
+def test_calculate_totals_walk_delivery_fee():
+    """Test that walk delivery method applies the fixed 5.00 delivery fee."""
     order = Order(
         order_id=1,
         status="Pending",
         items=[
-            OrderItem(order_item_id=1, order_id=1, quantity=2, item_price="10.00"),
-            OrderItem(order_item_id=2, order_id=1, quantity=1, item_price="3.50"),
+            OrderItem(order_item_id=1, order_id=1, quantity=1, item_price="10.00"),
         ],
         delivery_address="123 Main St",
-        delivery_fee="2.00",
+        delivery_method="walk",
     )
 
     PricingService.calculate_totals(order)
 
-    assert order.subtotal == Decimal("23.50")
-    assert order.delivery_fee == Decimal("2.00")
-    assert order.tax == Decimal("2.35")
-    assert order.total == Decimal("27.85")
+    assert order.delivery_fee == Decimal("5.00")
 
 
-def test_calculate_totals_empty_order():
-    """Test that calculate_totals handles an empty order with no items."""
+def test_calculate_totals_bike_delivery_fee():
+    """Test that bike delivery method applies the fixed 8.00 delivery fee."""
     order = Order(
         order_id=2,
         status="Pending",
-        items=[],
+        items=[
+            OrderItem(order_item_id=1, order_id=2, quantity=1, item_price="10.00"),
+        ],
         delivery_address="123 Main St",
-        delivery_fee="4.99",
+        delivery_method="bike",
     )
 
     PricingService.calculate_totals(order)
 
-    assert order.subtotal == Decimal("0.00")
-    assert order.delivery_fee == Decimal("4.99")
-    assert order.tax == Decimal("0.00")
-    assert order.total == Decimal("4.99")
+    assert order.delivery_fee == Decimal("8.00")
 
 
-def test_calculate_totals_applies_default_tax_rule():
-    """Tests PricingService applies the predefined tax rate to subtotal and includes it in total."""
+def test_calculate_totals_car_delivery_fee():
+    """Test that car delivery method applies the fixed 10.00 delivery fee."""
     order = Order(
         order_id=3,
         status="Pending",
         items=[
-            OrderItem(order_item_id=1, order_id=3, quantity=2, item_price="15.00"),
+            OrderItem(order_item_id=1, order_id=3, quantity=1, item_price="10.00"),
         ],
         delivery_address="123 Main St",
-        delivery_fee="5.00",
+        delivery_method="car",
     )
 
     PricingService.calculate_totals(order)
 
-    assert order.subtotal == Decimal("30.00")
-    assert order.tax == Decimal("3.00")   # 10% of 30.00
-    assert order.total == Decimal("38.00")  # 30.00 + 5.00 + 3.00
+    assert order.delivery_fee == Decimal("10.00")
+
+
+def test_calculate_totals_includes_delivery_fee_in_total():
+    """Test total calculation includes subtotal, tax, and fixed delivery fee."""
+    order = Order(
+        order_id=4,
+        status="Pending",
+        items=[
+            OrderItem(order_item_id=1, order_id=4, quantity=2, item_price="10.00"),
+        ],
+        delivery_address="123 Main St",
+        delivery_method="bike",
+    )
+
+    PricingService.calculate_totals(order)
+
+    assert order.subtotal == Decimal("20.00")
+    assert order.tax == Decimal("2.00")
+    assert order.delivery_fee == Decimal("8.00")
+    assert order.total == Decimal("30.00")
+
+
+def test_calculate_totals_rejects_invalid_delivery_method():
+    """Test that calculate_totals rejects an unsupported delivery method."""
+    order = Order(
+        order_id=5,
+        status="Pending",
+        items=[
+            OrderItem(order_item_id=1, order_id=5, quantity=1, item_price="10.00"),
+        ],
+        delivery_address="123 Main St",
+        delivery_method="drone",
+    )
+
+    with pytest.raises(ValueError, match="Delivery method must be one of: walk, bike, car"):
+        PricingService.calculate_totals(order)


### PR DESCRIPTION
## Summary
Implements SSR 38 by adding predefined fixed delivery fee rules based on delivery method and including the delivery fee in total order cost calculation.

## Changes made
- added `delivery_method` to order schemas
- added delivery method enum values:
  - `walk`
  - `bike`
  - `car`
- updated pricing logic to calculate `delivery_fee` automatically from `delivery_method`
- applied fixed delivery fee rules:
  - walk = 5.00
  - bike = 8.00
  - car = 10.00
- kept `delivery_fee` as a separate line item in the order cost breakdown
- updated total calculation to include subtotal, tax, and delivery fee
- added/updated tests for delivery fee and total calculation behavior

## Why
This satisfies SSR 38 and supports:
- showing delivery fee separately in the order breakdown
- automatically updating the fee based on delivery method
- applying delivery charges consistently using predefined rules

## Notes
- fixed fee only
- no distance, weather, or traffic logic added
- existing Decimal rounding behavior preserved