### PR TITLE
sr51 add notif get endpoint 

### DIFF
--- a/backend/app/repositories/notification_repo.py
+++ b/backend/app/repositories/notification_repo.py
@@ -1,7 +1,7 @@
 """Repository for notification records."""
 
 from datetime import datetime, timezone
-from typing import Dict
+from typing import Dict, List
 
 from backend.app.data.notification_data import NOTIFICATIONS
 
@@ -15,3 +15,8 @@ def create_notification(message: str, order_id: str) -> Dict[str, str]:
     }
     NOTIFICATIONS.append(record)
     return record
+
+
+def list_notification_records() -> List[Dict[str, str]]:
+    """Return notification records in newest-first order."""
+    return list(reversed(NOTIFICATIONS))

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,15 @@
+"""Router for notification endpoints."""
+
+from fastapi import APIRouter, Depends
+
+from backend.app.dependencies import get_current_user
+from backend.app.schemas.notification import NotificationResponse
+from backend.app.services import notification_service
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=list[NotificationResponse])
+def read_notifications(current_user=Depends(get_current_user)):
+    """Return newest-first notifications for the current user."""
+    return notification_service.list_notifications_for_user(current_user["user_id"])

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,11 @@
+"""Schemas for notification responses."""
+
+from pydantic import BaseModel
+
+
+class NotificationResponse(BaseModel):
+    """Response schema for notification records."""
+
+    message: str
+    timestamp: str
+    order_id: str

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,6 +1,13 @@
-"""Service layer for creating order notifications."""
+"""Service layer for creating and reading order notifications."""
 
-from backend.app.repositories.notification_repo import create_notification
+from backend.app.repositories.notification_repo import (
+    create_notification,
+    list_notification_records,
+)
+from backend.app.repositories.order_repo import get_order_record
+from backend.app.repositories.restaurant_repo import get_restaurant_record
+from backend.app.repositories.user_repo import get_user_role
+from backend.app.schemas.notification import NotificationResponse
 
 ORDER_PLACED_MESSAGE = "Order placed."
 ORDER_STATUS_CHANGED_MESSAGE_TEMPLATE = "Order status changed to {status}."
@@ -15,3 +22,30 @@ def create_order_status_changed_notification(order_id: str, new_status: str) -> 
     """Create a notification for an order status change."""
     message = ORDER_STATUS_CHANGED_MESSAGE_TEMPLATE.format(status=new_status)
     return create_notification(message, order_id)
+
+
+def list_notifications_for_user(user_id: str) -> list[NotificationResponse]:
+    """Return newest-first notifications visible to the current user."""
+    role = get_user_role(user_id)
+
+    if role not in {"customer", "manager"}:
+        return []
+
+    visible_notifications = []
+
+    for record in list_notification_records():
+        order = get_order_record(record["order_id"])
+        if order is None:
+            continue
+
+        if role == "customer":
+            if order["customer_id"] != user_id:
+                continue
+        else:
+            restaurant = get_restaurant_record(order["restaurant_id"])
+            if restaurant is None or restaurant.get("owner_id") != user_id:
+                continue
+
+        visible_notifications.append(NotificationResponse(**record))
+
+    return visible_notifications

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from backend.app.routers.profile import router as profile_router
 from backend.app.routers.checkouts import router as checkout_router
 from backend.app.routers.payments import router as payment_router
 from backend.app.routers.deliveries import router as deliveries_router
+from backend.app.routers.notifications import router as notifications_router
 
 app = FastAPI()
 app.include_router(auth_router)
@@ -19,6 +20,7 @@ app.include_router(profile_router)
 app.include_router(checkout_router)
 app.include_router(payment_router)
 app.include_router(deliveries_router)
+app.include_router(notifications_router)
 
 @app.get("/health")
 def health():

--- a/backend/tests/test_notification_repo.py
+++ b/backend/tests/test_notification_repo.py
@@ -1,0 +1,24 @@
+"""Unit tests for notification_repo.py."""
+
+from backend.app.data.notification_data import NOTIFICATIONS
+from backend.app.repositories.notification_repo import list_notification_records
+
+
+def setup_function():
+    """Reset notification state before each test."""
+    NOTIFICATIONS.clear()
+
+
+def test_list_notification_records_returns_newest_first():
+    """Notifications should be returned in reverse insertion order."""
+    NOTIFICATIONS.extend(
+        [
+            {"message": "First", "timestamp": "2026-03-16T10:00:00+00:00", "order_id": "1"},
+            {"message": "Second", "timestamp": "2026-03-16T10:05:00+00:00", "order_id": "2"},
+            {"message": "Third", "timestamp": "2026-03-16T10:10:00+00:00", "order_id": "3"},
+        ]
+    )
+
+    result = list_notification_records()
+
+    assert [record["order_id"] for record in result] == ["3", "2", "1"]

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -1,12 +1,30 @@
 """Unit tests for notification_service.py."""
+# pylint: disable=protected-access
 
+from backend.app.data import order_data
 from backend.app.data.notification_data import NOTIFICATIONS
+from backend.app.repositories import order_repo, restaurant_repo, user_repo
+from backend.app.repositories.notification_repo import create_notification
 from backend.app.services import notification_service
 
 
 def setup_function():
     """Reset notification state before each test."""
     NOTIFICATIONS.clear()
+    order_data._ORDERDB.clear()
+    order_data.NEXT_ORDER_ITEM_ID = 1
+    user_repo.reset_users()
+    restaurant_repo.reset_restaurants()
+
+
+def _create_order(customer_id: str, restaurant_id: int) -> dict:
+    """Create a minimal stored order for notification tests."""
+    return order_repo.create_order_record(
+        customer_id=customer_id,
+        restaurant_id=restaurant_id,
+        delivery_address="123 Test St",
+        items=[{"quantity": 1, "item_price": "12.50"}],
+    )
 
 
 def test_create_order_placed_notification_stores_minimal_record():
@@ -30,3 +48,56 @@ def test_create_order_status_changed_notification_stores_minimal_record():
     assert record["order_id"] == "abc1234"
     assert "timestamp" in record
     assert NOTIFICATIONS == [record]
+
+
+def test_list_notifications_for_customer_returns_only_own_newest_first():
+    """Customers should only see their own notifications in newest-first order."""
+    customer = user_repo.create_user("cust", "cust@email.com", "pw123")
+    user_repo.create_customer(customer["user_id"])
+
+    other_customer = user_repo.create_user("other", "other@email.com", "pw123")
+    user_repo.create_customer(other_customer["user_id"])
+
+    first_order = _create_order(customer["user_id"], 1)
+    create_notification("First", first_order["order_id"])
+
+    other_order = _create_order(other_customer["user_id"], 1)
+    create_notification("Other", other_order["order_id"])
+
+    newest_order = _create_order(customer["user_id"], 2)
+    create_notification("Newest", newest_order["order_id"])
+
+    result = notification_service.list_notifications_for_user(customer["user_id"])
+
+    assert [item.order_id for item in result] == [
+        newest_order["order_id"],
+        first_order["order_id"],
+    ]
+
+
+def test_list_notifications_for_manager_returns_only_owned_restaurant_orders():
+    """Managers should only see notifications for restaurants they own."""
+    manager = user_repo.create_user("mgr", "mgr@email.com", "pw123")
+    user_repo.create_manager(manager["user_id"])
+
+    other_manager = user_repo.create_user("other-mgr", "othermgr@email.com", "pw123")
+    user_repo.create_manager(other_manager["user_id"])
+
+    restaurant_repo.get_restaurant_record(1)["owner_id"] = manager["user_id"]
+    restaurant_repo.get_restaurant_record(2)["owner_id"] = other_manager["user_id"]
+
+    first_order = _create_order("customer-1", 1)
+    create_notification("First", first_order["order_id"])
+
+    other_order = _create_order("customer-2", 2)
+    create_notification("Other", other_order["order_id"])
+
+    newest_order = _create_order("customer-3", 1)
+    create_notification("Newest", newest_order["order_id"])
+
+    result = notification_service.list_notifications_for_user(manager["user_id"])
+
+    assert [item.order_id for item in result] == [
+        newest_order["order_id"],
+        first_order["order_id"],
+    ]

--- a/backend/tests/test_notifications_router.py
+++ b/backend/tests/test_notifications_router.py
@@ -1,0 +1,37 @@
+"""Unit tests for notifications router."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_current_user
+from backend.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def override_auth():
+    """Override auth dependency for all tests in this file."""
+    app.dependency_overrides[get_current_user] = lambda: {"user_id": "user-123"}
+    yield
+    app.dependency_overrides.clear()
+
+
+@patch("backend.app.routers.notifications.notification_service.list_notifications_for_user")
+def test_read_notifications_returns_200_and_calls_service(mock_list_notifications):
+    """GET /notifications should return the service payload for the current user."""
+    mock_list_notifications.return_value = [
+        {
+            "message": "Order placed.",
+            "timestamp": "2026-03-16T10:00:00+00:00",
+            "order_id": "abc1234",
+        }
+    ]
+
+    response = client.get("/notifications")
+
+    assert response.status_code == 200
+    assert response.json() == mock_list_notifications.return_value
+    mock_list_notifications.assert_called_once_with("user-123")


### PR DESCRIPTION
did sr51 The system shall provide an API endpoint for users to view their notifications, showing the newest notifications first. 

what i added
- notif response schema
- GET /notifications endpoint
- repo helper to return notifications newest first
- service helper to return only the current user notif stuff
- wired router into main
- added tests for repo/service/router

details:
- customer only sees notif for their own orders
- manager only sees notif for restaurant orders they own
- newest first is handled in notif repo with reversed list

notes:
- manager checks depend on owner id (see test files )