### PR TITLE
 sr52 notif visibility for drivers

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -13,6 +13,21 @@ ORDER_PLACED_MESSAGE = "Order placed."
 ORDER_STATUS_CHANGED_MESSAGE_TEMPLATE = "Order status changed to {status}."
 
 
+def _notification_is_visible_to_user(order: dict, user_id: str, role: str) -> bool:
+    """Return whether the user can view notifications for the given order."""
+    if role == "customer":
+        return order["customer_id"] == user_id
+
+    if role == "manager":
+        restaurant = get_restaurant_record(order["restaurant_id"])
+        return restaurant is not None and restaurant.get("owner_id") == user_id
+
+    if role == "driver":
+        return order.get("driver_id") == user_id
+
+    return False
+
+
 def create_order_placed_notification(order_id: str) -> dict:
     """Create a notification for a newly placed order."""
     return create_notification(ORDER_PLACED_MESSAGE, order_id)
@@ -28,7 +43,7 @@ def list_notifications_for_user(user_id: str) -> list[NotificationResponse]:
     """Return newest-first notifications visible to the current user."""
     role = get_user_role(user_id)
 
-    if role not in {"customer", "manager"}:
+    if role not in {"customer", "manager", "driver"}:
         return []
 
     visible_notifications = []
@@ -38,13 +53,8 @@ def list_notifications_for_user(user_id: str) -> list[NotificationResponse]:
         if order is None:
             continue
 
-        if role == "customer":
-            if order["customer_id"] != user_id:
-                continue
-        else:
-            restaurant = get_restaurant_record(order["restaurant_id"])
-            if restaurant is None or restaurant.get("owner_id") != user_id:
-                continue
+        if not _notification_is_visible_to_user(order, user_id, role):
+            continue
 
         visible_notifications.append(NotificationResponse(**record))
 

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -101,3 +101,28 @@ def test_list_notifications_for_manager_returns_only_owned_restaurant_orders():
         newest_order["order_id"],
         first_order["order_id"],
     ]
+
+
+def test_list_notifications_for_driver_returns_only_assigned_orders():
+    """Drivers should only see notifications for orders assigned to them."""
+    driver = user_repo.create_user("driver", "driver@email.com", "pw123")
+    user_repo.create_driver(driver["user_id"])
+
+    other_driver = user_repo.create_user("other-driver", "otherdriver@email.com", "pw123")
+    user_repo.create_driver(other_driver["user_id"])
+
+    matching_order = _create_order("customer-1", 1)
+    matching_order["driver_id"] = driver["user_id"]
+    matching_order["status"] = "Cooking"
+    create_notification("Match", matching_order["order_id"])
+
+    non_matching_order = _create_order("customer-2", 1)
+    non_matching_order["driver_id"] = other_driver["user_id"]
+    create_notification("Other Driver", non_matching_order["order_id"])
+
+    unassigned_order = _create_order("customer-3", 2)
+    create_notification("Unassigned", unassigned_order["order_id"])
+
+    result = notification_service.list_notifications_for_user(driver["user_id"])
+
+    assert [item.order_id for item in result] == [matching_order["order_id"]]


### PR DESCRIPTION
sr52 The system shall only return notifications the user is allowed to see based on their role and their relationship to the order (customer, restaurant owner/manager, delivery driver)

what changed:
- updated notif service visibility logic
- added missing driver coverage in notif service tests

basically before this, notif listing already handled customer and manager from sr51, but driver wasnt included yet. now driver can only see notif for orders where order.driver_id matches their user id

details:
- added a small helper in notification_service.py for notif visibility checks
- customer still sees notif for their own orders
- manager still sees notif for restaurant orders they own
- driver now sees notif only for orders assigned to them