### PR TITLE
implement sr55 and sr56 notification read/unread

### DIFF
--- a/backend/app/data/notification_data.py
+++ b/backend/app/data/notification_data.py
@@ -1,5 +1,5 @@
 """In-memory storage for notification records."""
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
-NOTIFICATIONS: List[Dict[str, str]] = []
+NOTIFICATIONS: List[Dict[str, Any]] = []

--- a/backend/app/repositories/notification_repo.py
+++ b/backend/app/repositories/notification_repo.py
@@ -1,22 +1,55 @@
 """Repository for notification records."""
 
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
+import shortuuid
 
 from backend.app.data.notification_data import NOTIFICATIONS
 
 
-def create_notification(message: str, order_id: str) -> Dict[str, str]:
+def _alloc_notification_id() -> str:
+    """Allocate and return the next notification_id."""
+    return shortuuid.ShortUUID().random(length=7)
+
+
+def create_notification(message: str, order_id: str) -> Dict[str, Any]:
     """Create and store a notification record."""
     record = {
+        "notification_id": _alloc_notification_id(),
         "message": message,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "order_id": order_id,
+        "read_by_user_ids": [],
     }
     NOTIFICATIONS.append(record)
     return record
 
 
-def list_notification_records() -> List[Dict[str, str]]:
+def get_notification_record(notification_id: str) -> Optional[Dict[str, Any]]:
+    """Return a notification record by its notification_id."""
+    return next(
+        (
+            record
+            for record in NOTIFICATIONS
+            if record.get("notification_id") == notification_id
+        ),
+        None,
+    )
+
+
+def mark_notification_as_read(notification_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+    """Mark a notification as read for a specific user."""
+    record = get_notification_record(notification_id)
+    if record is None:
+        return None
+
+    read_by_user_ids = record.setdefault("read_by_user_ids", [])
+    if user_id not in read_by_user_ids:
+        read_by_user_ids.append(user_id)
+
+    return record
+
+
+def list_notification_records() -> List[Dict[str, Any]]:
     """Return notification records in newest-first order."""
     return list(reversed(NOTIFICATIONS))

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -13,3 +13,15 @@ router = APIRouter(prefix="/notifications", tags=["notifications"])
 def read_notifications(current_user=Depends(get_current_user)):
     """Return newest-first notifications for the current user."""
     return notification_service.list_notifications_for_user(current_user["user_id"])
+
+
+@router.patch("/{notification_id}/read", response_model=NotificationResponse)
+def mark_notification_as_read(
+    notification_id: str,
+    current_user=Depends(get_current_user),
+):
+    """Mark a visible notification as read for the current user."""
+    return notification_service.mark_notification_as_read_for_user(
+        notification_id,
+        current_user["user_id"],
+    )

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 class NotificationResponse(BaseModel):
     """Response schema for notification records."""
 
+    notification_id: str
     message: str
     timestamp: str
     order_id: str
+    is_read: bool

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,12 +1,15 @@
-"""Service layer for creating and reading order notifications."""
+"""Service layer for creating and managing order notifications."""
 
 import logging
 from datetime import datetime, timezone
 from enum import Enum
+from fastapi import HTTPException
 
 from backend.app.repositories.notification_repo import (
     create_notification,
+    get_notification_record,
     list_notification_records,
+    mark_notification_as_read,
 )
 from backend.app.repositories.order_repo import get_order_record
 from backend.app.repositories.restaurant_repo import get_restaurant_record
@@ -70,6 +73,17 @@ def _notification_is_visible_to_user(order: dict, user_id: str, role: str) -> bo
     return False
 
 
+def _build_notification_response(record: dict, user_id: str) -> NotificationResponse:
+    """Build a notification response for the requesting user."""
+    return NotificationResponse(
+        notification_id=record["notification_id"],
+        message=record["message"],
+        timestamp=record["timestamp"],
+        order_id=record["order_id"],
+        is_read=user_id in record.get("read_by_user_ids", []),
+    )
+
+
 def create_order_placed_notification(order_id: str) -> dict:
     """Create a notification for a newly placed order."""
     return _create_notification_safely(
@@ -115,6 +129,36 @@ def list_notifications_for_user(user_id: str) -> list[NotificationResponse]:
         if not _notification_is_visible_to_user(order, user_id, role):
             continue
 
-        visible_notifications.append(NotificationResponse(**record))
+        visible_notifications.append(_build_notification_response(record, user_id))
 
     return visible_notifications
+
+
+def mark_notification_as_read_for_user(
+    notification_id: str,
+    user_id: str,
+) -> NotificationResponse:
+    """Mark a visible notification as read for the current user."""
+    role = get_user_role(user_id)
+    if role not in {"customer", "manager", "driver"}:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    record = get_notification_record(notification_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    order = get_order_record(record["order_id"])
+    if order is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    if not _notification_is_visible_to_user(order, user_id, role):
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to view this notification.",
+        )
+
+    updated_record = mark_notification_as_read(notification_id, user_id)
+    if updated_record is None:
+        raise HTTPException(status_code=500, detail="Failed to update notification")
+
+    return _build_notification_response(updated_record, user_id)

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -2,7 +2,8 @@
 # pylint: disable=protected-access
 
 from unittest.mock import patch
-
+import pytest
+from fastapi import HTTPException
 from backend.app.data import order_data
 from backend.app.data.notification_data import NOTIFICATIONS
 from backend.app.repositories import order_repo, restaurant_repo, user_repo
@@ -33,9 +34,11 @@ def test_create_order_placed_notification_stores_minimal_record():
     """Order placement notifications should store message, timestamp, and order_id."""
     record = notification_service.create_order_placed_notification("abc1234")
 
+    assert "notification_id" in record
     assert record["message"] == "Order placed."
     assert record["order_id"] == "abc1234"
     assert "timestamp" in record
+    assert record["read_by_user_ids"] == []
     assert NOTIFICATIONS == [record]
 
 
@@ -46,9 +49,11 @@ def test_create_order_status_changed_notification_stores_minimal_record():
         "Cooking",
     )
 
+    assert "notification_id" in record
     assert record["message"] == "Order status changed to Cooking."
     assert record["order_id"] == "abc1234"
     assert "timestamp" in record
+    assert record["read_by_user_ids"] == []
     assert NOTIFICATIONS == [record]
 
 
@@ -56,9 +61,11 @@ def test_create_driver_assigned_notification_stores_minimal_record():
     """Driver assignment notifications should store message, timestamp, and order_id."""
     record = notification_service.create_driver_assigned_notification("abc1234")
 
+    assert "notification_id" in record
     assert record["message"] == "You have been assigned a delivery."
     assert record["order_id"] == "abc1234"
     assert "timestamp" in record
+    assert record["read_by_user_ids"] == []
     assert NOTIFICATIONS == [record]
 
 
@@ -106,6 +113,7 @@ def test_list_notifications_for_customer_returns_only_own_newest_first():
         newest_order["order_id"],
         first_order["order_id"],
     ]
+    assert [item.is_read for item in result] == [False, False]
 
 
 def test_list_notifications_for_manager_returns_only_owned_restaurant_orders():
@@ -159,3 +167,55 @@ def test_list_notifications_for_driver_returns_only_assigned_orders():
     result = notification_service.list_notifications_for_user(driver["user_id"])
 
     assert [item.order_id for item in result] == [matching_order["order_id"]]
+
+
+def test_mark_notification_as_read_updates_only_current_user():
+    """Marking a notification as read should only affect the current user."""
+    customer = user_repo.create_user("cust", "cust@email.com", "pw123")
+    user_repo.create_customer(customer["user_id"])
+
+    manager = user_repo.create_user("mgr", "mgr@email.com", "pw123")
+    user_repo.create_manager(manager["user_id"])
+    restaurant_repo.get_restaurant_record(1)["owner_id"] = manager["user_id"]
+
+    order = _create_order(customer["user_id"], 1)
+    record = create_notification("Order placed.", order["order_id"])
+
+    customer_notifications = notification_service.list_notifications_for_user(customer["user_id"])
+    manager_notifications = notification_service.list_notifications_for_user(manager["user_id"])
+    assert customer_notifications[0].is_read is False
+    assert manager_notifications[0].is_read is False
+
+    result = notification_service.mark_notification_as_read_for_user(
+        record["notification_id"],
+        customer["user_id"],
+    )
+
+    assert result.notification_id == record["notification_id"]
+    assert result.is_read is True
+
+    customer_notifications = notification_service.list_notifications_for_user(customer["user_id"])
+    manager_notifications = notification_service.list_notifications_for_user(manager["user_id"])
+    assert customer_notifications[0].is_read is True
+    assert manager_notifications[0].is_read is False
+
+
+def test_mark_notification_as_read_rejects_hidden_notification():
+    """Users should not be able to mark invisible notifications as read."""
+    customer = user_repo.create_user("cust", "cust@email.com", "pw123")
+    user_repo.create_customer(customer["user_id"])
+
+    other_customer = user_repo.create_user("other", "other@email.com", "pw123")
+    user_repo.create_customer(other_customer["user_id"])
+
+    order = _create_order(customer["user_id"], 1)
+    record = create_notification("Order placed.", order["order_id"])
+
+    with pytest.raises(HTTPException) as exc:
+        notification_service.mark_notification_as_read_for_user(
+            record["notification_id"],
+            other_customer["user_id"],
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Not authorized to view this notification."

--- a/backend/tests/test_notifications_router.py
+++ b/backend/tests/test_notifications_router.py
@@ -24,9 +24,11 @@ def test_read_notifications_returns_200_and_calls_service(mock_list_notification
     """GET /notifications should return the service payload for the current user."""
     mock_list_notifications.return_value = [
         {
+            "notification_id": "notif-123",
             "message": "Order placed.",
             "timestamp": "2026-03-16T10:00:00+00:00",
             "order_id": "abc1234",
+            "is_read": False,
         }
     ]
 
@@ -35,3 +37,21 @@ def test_read_notifications_returns_200_and_calls_service(mock_list_notification
     assert response.status_code == 200
     assert response.json() == mock_list_notifications.return_value
     mock_list_notifications.assert_called_once_with("user-123")
+
+
+@patch("backend.app.routers.notifications.notification_service.mark_notification_as_read_for_user")
+def test_mark_notification_as_read_returns_200_and_calls_service(mock_mark_notification):
+    """PATCH /notifications/{notification_id}/read should mark the notification as read."""
+    mock_mark_notification.return_value = {
+        "notification_id": "notif-123",
+        "message": "Order placed.",
+        "timestamp": "2026-03-16T10:00:00+00:00",
+        "order_id": "abc1234",
+        "is_read": True,
+    }
+
+    response = client.patch("/notifications/notif-123/read")
+
+    assert response.status_code == 200
+    assert response.json() == mock_mark_notification.return_value
+    mock_mark_notification.assert_called_once_with("notif-123", "user-123")


### PR DESCRIPTION
implemented SR55 and SR56 (cant be one by one because theyre highly related)

SR55
new notifications now start as unread by default

SR56
users can now mark a notification as read

changes
- added notification_id to stored notifications
- added  read_by_user_ids so notifications start unread for everyone
- updated notification listing to compute is_read per requesting user
- added centralized service logic to mark one notification as read for one user
- reused existing order based visibility checks before allowing mark as read