### PR TITLE
refactor pricing_service use httpexception like other services

### DIFF
--- a/backend/app/services/pricing_service.py
+++ b/backend/app/services/pricing_service.py
@@ -1,6 +1,7 @@
 """Pricing service logic for order totals."""
 
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from fastapi import HTTPException
 
 from backend.app.schemas.order import DeliveryMethod
 
@@ -31,39 +32,45 @@ class PricingService:  # pylint: disable=too-few-public-methods
     def _validate_order(order) -> None:
         """Validate required order-level fields."""
         if order is None:
-            raise ValueError("Order is required")
+            raise HTTPException(status_code=400, detail="Order is required")
 
         if not hasattr(order, "items") or order.items is None:
-            raise ValueError("Order items are required")
+            raise HTTPException(status_code=400, detail="Order items are required")
 
     @staticmethod
     def _validate_item(item) -> tuple[int, Decimal]:
         """Validate an order item and return quantity and decimal price."""
         if item is None:
-            raise ValueError("Order item is required")
+            raise HTTPException(status_code=400, detail="Order item is required")
 
         if not hasattr(item, "quantity"):
-            raise ValueError("Order item quantity is required")
+            raise HTTPException(status_code=400, detail="Order item quantity is required")
         if not hasattr(item, "item_price"):
-            raise ValueError("Order item price is required")
+            raise HTTPException(status_code=400, detail="Order item price is required")
 
         quantity = item.quantity
         if quantity is None:
-            raise ValueError("Order item quantity is required")
+            raise HTTPException(status_code=400, detail="Order item quantity is required")
         if quantity <= 0:
-            raise ValueError("Order item quantity must be greater than zero")
+            raise HTTPException(
+                status_code=400,
+                detail="Order item quantity must be greater than zero",
+            )
 
         price = item.item_price
         if price is None:
-            raise ValueError("Order item price is required")
+            raise HTTPException(status_code=400, detail="Order item price is required")
 
         try:
             price_decimal = Decimal(str(price))
         except (InvalidOperation, ValueError, TypeError) as exc:
-            raise ValueError("Order item price must be a valid number") from exc
+            raise HTTPException(
+                status_code=400,
+                detail="Order item price must be a valid number",
+            ) from exc
 
         if price_decimal < 0:
-            raise ValueError("Order item price cannot be negative")
+            raise HTTPException(status_code=400, detail="Order item price cannot be negative")
 
         return quantity, price_decimal
 
@@ -73,12 +80,15 @@ class PricingService:  # pylint: disable=too-few-public-methods
         method = getattr(delivery_method, "value", delivery_method)
 
         if method is None:
-            raise ValueError("Delivery method is required")
+            raise HTTPException(status_code=400, detail="Delivery method is required")
 
         try:
             method_enum = DeliveryMethod(str(method).strip().lower())
         except ValueError as exc:
-            raise ValueError("Delivery method must be one of: walk, bike, car") from exc
+            raise HTTPException(
+                status_code=400,
+                detail="Delivery method must be one of: walk, bike, car",
+            ) from exc
 
         return _to_money(DELIVERY_FEE_BY_METHOD[method_enum])
 
@@ -89,10 +99,10 @@ class PricingService:  # pylint: disable=too-few-public-methods
         try:
             tax_rate = Decimal(str(tax_rate_raw))
         except (InvalidOperation, ValueError, TypeError) as exc:
-            raise ValueError("Tax rate must be a valid number") from exc
+            raise HTTPException(status_code=400, detail="Tax rate must be a valid number") from exc
 
         if tax_rate < 0:
-            raise ValueError("Tax rate cannot be negative")
+            raise HTTPException(status_code=400, detail="Tax rate cannot be negative")
 
         return tax_rate
 

--- a/backend/tests/test_pricing_service.py
+++ b/backend/tests/test_pricing_service.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 
 from backend.app.services.pricing_service import PricingService
 
@@ -153,8 +154,11 @@ def test_calculate_delivery_fee_car():
 
 def test_validate_order_rejects_none_order():
     """Test that order validation rejects a missing order."""
-    with pytest.raises(ValueError, match="Order is required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_order(None)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order is required"
 
 
 def test_validate_order_rejects_missing_items():
@@ -167,62 +171,86 @@ def test_validate_order_rejects_missing_items():
         delivery_method="walk",
     )
 
-    with pytest.raises(ValueError, match="Order items are required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_order(order)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order items are required"
 
 
 def test_validate_item_rejects_none_item():
     """Test that item validation rejects a missing order item."""
-    with pytest.raises(ValueError, match="Order item is required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(None)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item is required"
 
 
 def test_validate_item_rejects_none_quantity():
     """Test that item validation rejects an item with a missing quantity."""
     item = OrderItem(order_item_id=1, order_id=6, quantity=None, item_price="10.00")
 
-    with pytest.raises(ValueError, match="Order item quantity is required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item quantity is required"
 
 
 def test_validate_item_rejects_zero_quantity():
     """Test that item validation rejects an item with zero quantity."""
     item = OrderItem(order_item_id=1, order_id=7, quantity=0, item_price="10.00")
 
-    with pytest.raises(ValueError, match="Order item quantity must be greater than zero"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item quantity must be greater than zero"
 
 
 def test_validate_item_rejects_negative_quantity():
     """Test that item validation rejects an item with a negative quantity."""
     item = OrderItem(order_item_id=1, order_id=8, quantity=-1, item_price="10.00")
 
-    with pytest.raises(ValueError, match="Order item quantity must be greater than zero"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item quantity must be greater than zero"
 
 
 def test_validate_item_rejects_none_item_price():
     """Test that item validation rejects an item with a missing price."""
     item = OrderItem(order_item_id=1, order_id=9, quantity=1, item_price=None)
 
-    with pytest.raises(ValueError, match="Order item price is required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item price is required"
 
 
 def test_validate_item_rejects_invalid_item_price():
     """Test that item validation rejects an item with a non-numeric price."""
     item = OrderItem(order_item_id=1, order_id=10, quantity=1, item_price="abc")
 
-    with pytest.raises(ValueError, match="Order item price must be a valid number"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item price must be a valid number"
 
 
 def test_validate_item_rejects_negative_item_price():
     """Test that item validation rejects an item with a negative price."""
     item = OrderItem(order_item_id=1, order_id=11, quantity=1, item_price="-5.00")
 
-    with pytest.raises(ValueError, match="Order item price cannot be negative"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_item(item)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Order item price cannot be negative"
 
 
 def test_validate_tax_rate_rejects_invalid_tax_rate():
@@ -236,8 +264,11 @@ def test_validate_tax_rate_rejects_invalid_tax_rate():
         tax_rate="abc",
     )
 
-    with pytest.raises(ValueError, match="Tax rate must be a valid number"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_tax_rate(order)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Tax rate must be a valid number"
 
 
 def test_validate_tax_rate_rejects_negative_tax_rate():
@@ -251,17 +282,26 @@ def test_validate_tax_rate_rejects_negative_tax_rate():
         tax_rate="-0.10",
     )
 
-    with pytest.raises(ValueError, match="Tax rate cannot be negative"):
+    with pytest.raises(HTTPException) as exc:
         PricingService._validate_tax_rate(order)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Tax rate cannot be negative"
 
 
 def test_calculate_delivery_fee_rejects_invalid_delivery_method():
     """Test that delivery fee calculation rejects an unsupported delivery method."""
-    with pytest.raises(ValueError, match="Delivery method must be one of: walk, bike, car"):
+    with pytest.raises(HTTPException) as exc:
         PricingService.calculate_delivery_fee("plane")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Delivery method must be one of: walk, bike, car"
 
 
 def test_calculate_delivery_fee_rejects_missing_delivery_method():
     """Test that delivery fee calculation rejects a missing delivery method."""
-    with pytest.raises(ValueError, match="Delivery method is required"):
+    with pytest.raises(HTTPException) as exc:
         PricingService.calculate_delivery_fee(None)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Delivery method is required"


### PR DESCRIPTION
refactor

made pricing_service use HTTPException instead of valueerror for its validation/business rule failures so it matches how the other service files already do errors

main change
replaced the existing ValueError branches with HTTPException(status_code=400, detail="...")

updated in:
- validate_order
- validate_item
- calculate_delivery_fee
- validate_tax_rate

pricing logic did not change.

## tests
updated the pricing tests to stop expecting `ValueError` and instead check:
- HTTPException
- status_code == 400
- same error message in detail