### PR TITLE
add order integration test file for pending order update flow

### DIFF
--- a/backend/tests/test_order_integration.py
+++ b/backend/tests/test_order_integration.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from backend.app.data import cart_data, notification_data, order_data, payment_data
 from backend.app.dependencies import get_current_user
 from backend.app.repositories import restaurant_repo, user_repo
+from backend.app.schemas.payment import PaymentStatus
 from backend.main import app
 
 client = TestClient(app)
@@ -92,7 +93,7 @@ def _pay_order(order_id: str) -> None:
     """Pay for an order through the real payment route."""
     payment_res = client.post(f"/payments/{order_id}", json=VALID_CARD)
     assert payment_res.status_code == 201
-    assert payment_res.json()["status"] == "Accepted"
+    assert payment_res.json()["status"] == PaymentStatus.ACCEPTED.value
 
 
 def test_customer_can_update_own_pending_order_delivery_address():


### PR DESCRIPTION
- create orders through checkout first, then test the real /orders/order_id update route
- added coverage for:
  - customer updating their own pending order address
  - another customer getting blocked
  - manager owner being allowed
  - non owner manager getting blocked
  - orders not being editable anymore after payment moves them to cooking

we already had order behavior tested in a bunch of places, but not really a dedicated order integration file for the pending order update route itself.
checkout/payment/pricing tests were already covering other parts of the order flow, so this keeps the new file focused on the missing order-specific stuff:
- auth
- pending-only editability
- simple persisted order field updates